### PR TITLE
[repl][config] alias REPL actions

### DIFF
--- a/packages/config/src/config/__tests__/__snapshots__/base.test.ts.snap
+++ b/packages/config/src/config/__tests__/__snapshots__/base.test.ts.snap
@@ -24,6 +24,15 @@ exports[`Config$Base static properties should correctly 1`] = `
     }
   },
   repl: {
+    actions: {
+      ancestors: 'ancs',
+      descriptors: 'desc',
+      loadedModules: 'loaded',
+      propertyList: 'lp',
+      methodList: 'ls',
+      prototype: 'proto',
+      definition: 'show'
+    },
     loadModules: [
       'src/**/{forms,models,records}/**/*.{js,ts}',
       '!src/**/__tests__/*.test.{js,ts}'

--- a/packages/config/src/config/__tests__/base.test.ts
+++ b/packages/config/src/config/__tests__/base.test.ts
@@ -25,6 +25,15 @@ describe('Config$Base', () => {
           },
         },
         repl: {
+          actions: {
+            ancestors: 'ancs',
+            descriptors: 'desc',
+            loadedModules: 'loaded',
+            propertyList: 'lp',
+            methodList: 'ls',
+            prototype: 'proto',
+            definition: 'show',
+          },
           loadModules: [
             'src/**/{forms,models,records}/**/*.{js,ts}',
             '!src/**/__tests__/*.test.{js,ts}',
@@ -60,6 +69,15 @@ describe('Config$Base', () => {
             },
           },
           repl: {
+            actions: {
+              ancestors: 'ancs',
+              descriptors: 'desc',
+              loadedModules: 'loaded',
+              propertyList: 'lp',
+              methodList: 'ls',
+              prototype: 'proto',
+              definition: 'show',
+            },
             loadModules: [
               'src/**/{forms,models,records}/**/*.{js,ts}',
               '!src/**/__tests__/*.test.{js,ts}',
@@ -86,6 +104,15 @@ describe('Config$Base', () => {
     describe('when default', () => {
       it('should correctly', () => {
         expect(Config.rueREPL()).toEqual({
+          actions: {
+            ancestors: 'ancs',
+            descriptors: 'desc',
+            loadedModules: 'loaded',
+            propertyList: 'lp',
+            methodList: 'ls',
+            prototype: 'proto',
+            definition: 'show',
+          },
           loadModules: [
             'src/**/{forms,models,records}/**/*.{js,ts}',
             '!src/**/__tests__/*.test.{js,ts}',

--- a/packages/config/src/config/base.ts
+++ b/packages/config/src/config/base.ts
@@ -34,6 +34,15 @@ export class Config$Base {
       },
     },
     repl: {
+      actions: {
+        ancestors: 'ancs',
+        descriptors: 'desc',
+        loadedModules: 'loaded',
+        propertyList: 'lp',
+        methodList: 'ls',
+        prototype: 'proto',
+        definition: 'show',
+      },
       loadModules: [
         'src/**/{forms,models,records}/**/*.{js,ts}',
         '!src/**/__tests__/*.test.{js,ts}',

--- a/packages/config/src/config/types.ts
+++ b/packages/config/src/config/types.ts
@@ -19,6 +19,15 @@ export type RueConfig = {
     };
   };
   repl: {
+    actions?: {
+      ancestors?: string;
+      descriptors?: string;
+      loadedModules?: string;
+      propertyList?: string;
+      methodList?: string;
+      prototype?: string;
+      definition?: string;
+    };
     loadModules: string[];
     moduleAliases: {
       [aliasName: string]: string;

--- a/packages/examples/rue.config.js
+++ b/packages/examples/rue.config.js
@@ -19,6 +19,15 @@ module.exports = {
     },
   },
   repl: {
+    actions: {
+      ancestors: 'ancs',
+      descriptors: 'desc',
+      loadedModules: 'loaded',
+      propertyList: 'lp',
+      methodList: 'ls',
+      prototype: 'proto',
+      definition: 'show',
+    },
     loadModules: [
       'src/**/{forms,models,records}/**/*.ts',
       'src/setup/rc.ts',

--- a/packages/repl/src/commands/core.ts
+++ b/packages/repl/src/commands/core.ts
@@ -1,6 +1,7 @@
 import { REPLServer } from 'repl';
 // rue packages
 import { ActiveSupport$Base as Support } from '@rue/activesupport';
+import { Config$Base as Config } from '@rue/config';
 
 // locals
 import { Repl$Base as Repl } from '@/repl';
@@ -35,9 +36,18 @@ function execAction(objName: string, repl: replt.REPLServer, callback: (obj: any
   }
 }
 
+const defaultAliases = Config.default.repl.actions;
+const udfAliases = Config.rueREPL().actions;
+const useAliases = Object.keys(defaultAliases).reduce((acc, key) => {
+  const defaultValue = defaultAliases[key];
+  const udfValue = udfAliases[key];
+  acc[key] = udfValue && udfValue != '' ? udfValue : defaultValue;
+  return acc;
+}, {} as typeof udfAliases);
+
 // this is bound to an instance(class) of Repl(Builtin)
 const commands: t.Commands = {
-  ls: {
+  [useAliases.methodList]: {
     help: '[Rue] Display method list',
     action: function (objName: string) {
       const _this = this as replt.REPLServer;
@@ -50,7 +60,7 @@ const commands: t.Commands = {
       _this.displayPrompt();
     },
   },
-  lp: {
+  [useAliases.propertyList]: {
     help: '[Rue] Display property list',
     action: function (objName: string) {
       const _this = this as replt.REPLServer;
@@ -63,7 +73,7 @@ const commands: t.Commands = {
       _this.displayPrompt();
     },
   },
-  proto: {
+  [useAliases.prototype]: {
     help: '[Rue] Display Object.getPrototypeOf result',
     action: function (objName: string) {
       const _this = this as replt.REPLServer;
@@ -76,7 +86,7 @@ const commands: t.Commands = {
       _this.displayPrompt();
     },
   },
-  desc: {
+  [useAliases.descriptors]: {
     help: '[Rue] Display Object.getOwnPropertyDescriptors result',
     action: function (objName: string) {
       const _this = this as replt.REPLServer;
@@ -89,7 +99,7 @@ const commands: t.Commands = {
       _this.displayPrompt();
     },
   },
-  ancs: {
+  [useAliases.ancestors]: {
     help: '[Rue] Display ancestors (like Ruby)',
     action: function (objName: string) {
       const _this = this as replt.REPLServer;
@@ -102,7 +112,7 @@ const commands: t.Commands = {
       _this.displayPrompt();
     },
   },
-  loaded: {
+  [useAliases.loadedModules]: {
     help: '[Rue] Display loaded Classes or RueModules',
     action: async function () {
       const _this = this as replt.REPLServer;
@@ -114,7 +124,7 @@ const commands: t.Commands = {
       _this.displayPrompt();
     },
   },
-  show: {
+  [useAliases.definition]: {
     help:
       '[Rue] Display method definition (format: <Class> or <Class>.<staticMethod> or <Class>.prototype.<instanceMethod>)',
     action: function (objName: string) {


### PR DESCRIPTION
### Summary

Resolve #31 

- `@rue/config`
  - Add config about `aliases actions`
- `@rue/repl`
  - use `@rue/config` for actions
  
```diff
module.exports = {
  backend: {
    mock_server: {
      loadData: ['./backend/mock_server/data/**/*.{js,json}'],
      dist: {
        db: './backend/mock_server/db.json',
        routes: './backend/mock_server/routes.json',
      },
    },
  },
  cli: {
    commands: {
      console: {
        nodeREPL: {
          prompt: '🍛 > ',
          useColors: true,
        },
      },
    },
  },
  repl: {
+    actions: {
+      ancestors: 'ancs',
+      descriptors: 'desc',
+      loadedModules: 'loaded',
+      propertyList: 'lp',
+      methodList: 'ls',
+      prototype: 'proto',
+      definition: 'show',
+    },
    loadModules: [
      'src/**/{forms,models,records}/**/*.ts',
      'src/setup/rc.ts',
      '!src/**/__tests__/*.test.{js,ts}',
    ],
    moduleAliases: {
      '@': './src',
    },
  },
};
```


### Check

- [x] yarn test
- [x] yarn build
- [x] yarn fmt
